### PR TITLE
Add a max-width to improve content readability

### DIFF
--- a/lib/sss/sss.css
+++ b/lib/sss/sss.css
@@ -4,6 +4,10 @@ body {
 	line-height: 1.5;
 	margin: 2em;
 }
+.markdownRoot {
+	margin: 0 auto;
+	max-width: 60em;
+}
 
 h1, h2, h3, h4, h5, h6 {
 	font-weight: normal;


### PR DESCRIPTION
Simply filling the width of the browser pane doesn't look good.