### PR TITLE
Quick & dirty custom CSS in the configuration page

### DIFF
--- a/ext/content.js
+++ b/ext/content.js
@@ -10,6 +10,16 @@ function addExtensionStylesheet(href, media) {
 	addStylesheet(browser.extension.getURL(href), media);
 }
 
+function addCustomStylesheet() {
+	browser.storage.sync.get('custom_css').then(storage => {
+		if ('custom_css' in storage) {
+			var style = document.createElement('style');
+			style.textContent = storage.custom_css;
+			document.head.appendChild(style);
+		}
+	});
+}
+
 function makeAnchor(node) {
 	// From @tomfun https://gist.github.com/asabaylus/3071099#gistcomment-1622315
 	var anchor = node.textContent.trim().toLowerCase().replace(/[^\w\- ]+/g, ' ').replace(/\s+/g, '-').replace(/\-+$/, '');
@@ -57,7 +67,7 @@ function processMarkdown(textContent) {
 	addExtensionStylesheet('/lib/sss/sss.print.css', 'print');
 	addExtensionStylesheet('/lib/highlightjs/styles/default.css');
 	// User-defined stylesheet.
-	addStylesheet('_markdown.css');
+	addCustomStylesheet();
 
 	// This is considered a good practice for mobiles.
 	var viewport = document.createElement('meta');

--- a/ext/options.html
+++ b/ext/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+</head>
+
+<body>
+	<h3>Custom CSS</h3>
+	<p>Enter custom CSS to be applied to Markdown pages here:<br />
+		<textarea id="custom_css" style="margin: 10px; width:90%; min-height:30em;"></textarea>
+	</p>
+	<script src="options.js">
+	</script>
+</body>
+
+</html>

--- a/ext/options.js
+++ b/ext/options.js
@@ -1,0 +1,9 @@
+var textarea = document.getElementById('custom_css');
+browser.storage.sync.get('custom_css').then(storage => {
+	if ('custom_css' in storage)
+		textarea.value = storage.custom_css;
+}).then(() => {
+	textarea.onchange = () => {
+		browser.storage.sync.set({custom_css: textarea.value});
+	};
+});

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 	"description": "Displays markdown documents beautified in your browser.",
 
 	"permissions": [
-		"activeTab", "tabs", "<all_urls>"
+		"activeTab", "tabs", "<all_urls>", "storage"
 	],
 
 	"icons": {
@@ -22,5 +22,11 @@
 		"lib/sss/sss.css",
 		"lib/sss/sss.print.css",
 		"lib/highlightjs/styles/default.css"
-	]
+	],
+
+	"options_ui":
+	{
+		"page": "ext/options.html",
+		"browser_style": true
+	}
 }


### PR DESCRIPTION
More satisfying fix for #14, and pretty flexible. If anyone desperately wants #1 they can now copy/paste the appropriate CSS into the "custom CSS" box.

I also removed the `_markdown.css` support as it was not needed anymore (and if you really want URL-specific styling, you can use `@-moz-document` rules in the CSS).