### PR TITLE
Feature/optional permissions

### DIFF
--- a/ext/background.js
+++ b/ext/background.js
@@ -1,20 +1,55 @@
-﻿browser.tabs.onUpdated.addListener((id, changeInfo, tab) => {
+﻿const md_extension_pattern = /\.m(arkdown|kdn?|d(o?wn)?)$/i;
 
-	const markdownFileExtension = /\.m(arkdown|kdn?|d(o?wn)?)(\?.*)?(#.*)?$/i;
-
-	if (changeInfo.status === 'complete' && markdownFileExtension.test(tab.url)) {
-
-		// Support loading additional scripts on demand by content script.
-		browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-			if (message.scriptToInject) {
-				browser.tabs.executeScript(sender.tab.id, { file: message.scriptToInject }, () => {
-					sendResponse({ success: true });
-				});
-				return true;
-			}
-			return false;
+// Support loading additional scripts on demand by content script.
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+	if (message.scriptToInject) {
+		browser.tabs.executeScript(sender.tab.id, { file: message.scriptToInject }, () => {
+			sendResponse({ success: true });
 		});
+		return true;
+	}
+	return false;
+});
 
-		browser.tabs.executeScript(id, { file: "/ext/content.js" });
+// Enable/disable requesting permissions
+function setButton(tab, permsGiven) {
+	var url = new URL(tab.url);
+	var name = url.protocol == 'file:' ? 'local files' : url.host;
+
+	if (permsGiven) {
+		browser.browserAction.setTitle({tabId: tab.id, title: 'Markdown rendering already activated for '+ name});
+		browser.browserAction.disable(tab.id);
+	} else  {
+		browser.browserAction.setTitle({tabId: tab.id, title: 'Enable Markdown rendering for '+ name});
+		browser.browserAction.enable(tab.id);
+	}
+}
+
+browser.tabs.query({}).then(tabs => tabs.forEach(tab => {
+	browser.permissions.contains({origins: [tab.url]}).then(allowed => setButton(tab, allowed))
+}));
+
+// Make button request permission for current domain
+browser.browserAction.onClicked.addListener(activeTab => {
+	var url = new URL(activeTab.url);
+	var perm = {origins: [url.protocol == 'file:' ? "file:///*" : '*://' + url.host + '/*']};
+	browser.permissions.request(perm).then(allowed => {
+		if (allowed && md_extension_pattern.test(url.pathname)) {
+			browser.tabs.executeScript(activeTab.id, { file: '/ext/content.js' });
+		}
+		setButton(activeTab, allowed);
+	});
+});
+
+browser.tabs.onUpdated.addListener((id, changeInfo, tab) => {
+	if ('status' in changeInfo && changeInfo.status === 'complete') {
+		// check permissions, maybe inject our code, and update button
+		browser.permissions.contains({origins: [tab.url]}).then(allowed => {
+			var url = new URL(tab.url);
+			if (allowed && md_extension_pattern.test(url.pathname)) {
+				browser.tabs.executeScript(id, { file: '/ext/content.js' });
+			}
+			setButton(tab, allowed);
+		});
 	}
 });

--- a/ext/options.css
+++ b/ext/options.css
@@ -5,3 +5,6 @@
 	display: inline-block;
 	margin:1ex;
 }
+#all_origins {
+	font-weight:bold;
+}

--- a/ext/options.css
+++ b/ext/options.css
@@ -1,0 +1,7 @@
+#origins {
+	list-style-type: none;
+}
+#origins li {
+	display: inline-block;
+	margin:1ex;
+}

--- a/ext/options.html
+++ b/ext/options.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<link rel="stylesheet" type="text/css" href="options.css" />
+</head>
+
+<body>
+	<h3>Granted permissions</h3>
+	<p>Rendering Markdown is enabled on pages of the following domains (click to remove):</p>
+	<ul id="origins">
+	</ul>
+	<script src="options.js">
+	</script>
+</body>
+
+</html>

--- a/ext/options.html
+++ b/ext/options.html
@@ -8,7 +8,8 @@
 
 <body>
 	<h3>Granted permissions</h3>
-	<p>Rendering Markdown is enabled on pages of the following domains (click to remove):</p>
+	<p><span id="all_origins">To enable markdown rendering for all websites, click the toolbar button from this page.</span>
+	<br />Rendering Markdown is enabled on pages of the following domains (click to remove):</p>
 	<ul id="origins">
 	</ul>
 	<script src="options.js">

--- a/ext/options.js
+++ b/ext/options.js
@@ -1,0 +1,27 @@
+function list_permitted_origins(perm) {
+	var list = document.getElementById('origins');
+
+	while (list.hasChildNodes()) {
+		list.removeChild(list.lastChild);
+	}
+
+	var origins = perm.origins.filter(orig => !orig.startsWith('moz-extension://'));
+	if (!origins.length)
+		list.appendChild(document.createElement('li')).textContent = 'No domains to be shown';
+
+	origins.forEach(orig => {
+		var btn = document.createElement('button');
+		btn.textContent = orig.startsWith('file://') ? 'local files' : orig.split('/')[2];
+		btn.onclick = () => {
+			browser.permissions.remove({origins: [orig]}).then(removed => {
+				if (removed) {
+					list.removeChild(btn.parentNode);
+				}
+			});
+		};
+
+		list.appendChild(document.createElement('li')).appendChild(btn);
+	});
+}
+
+browser.permissions.getAll().then(list_permitted_origins);

--- a/ext/options.js
+++ b/ext/options.js
@@ -6,12 +6,22 @@ function list_permitted_origins(perm) {
 	}
 
 	var origins = perm.origins.filter(orig => !orig.startsWith('moz-extension://'));
-	if (!origins.length)
+
+	if (!origins.length) {
 		list.appendChild(document.createElement('li')).textContent = 'No domains to be shown';
+		return;
+	}
 
 	origins.forEach(orig => {
 		var btn = document.createElement('button');
-		btn.textContent = orig.startsWith('file://') ? 'local files' : orig.split('/')[2];
+
+		if (orig === '*://*/*')
+			btn.textContent = 'ALL web sites !';
+		else if (orig.startsWith('file://'))
+			btn.textContent = 'local files';
+		else
+			btn.textContent = orig.split('/')[2];
+
 		btn.onclick = () => {
 			browser.permissions.remove({origins: [orig]}).then(removed => {
 				if (removed) {
@@ -24,4 +34,14 @@ function list_permitted_origins(perm) {
 	});
 }
 
+// list when opening, and refresh page whenever permissions are added
 browser.permissions.getAll().then(list_permitted_origins);
+browser.runtime.onMessage.addListener(message => {
+	if ('requested' in message && 'granted' in message) {
+		if (message.granted) {
+			browser.permissions.getAll().then(list_permitted_origins);
+		}
+		return true;
+	}
+	return false;
+});

--- a/manifest.json
+++ b/manifest.json
@@ -32,5 +32,11 @@
 		"lib/sss/sss.css",
 		"lib/sss/sss.print.css",
 		"lib/highlightjs/styles/default.css"
-	]
+	],
+
+	"options_ui":
+	{
+		"page": "ext/options.html",
+		"browser_style": true
+	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,18 @@
 	"description": "Displays markdown documents beautified in your browser.",
 
 	"permissions": [
-		"activeTab", "tabs", "<all_urls>"
+		"tabs",
+		"storage"
 	],
+
+	"optional_permissions": [
+		"*://*/*",
+		"file:///*"
+	],
+
+	"browser_action": {
+		"default_icon": "ext/markdown-mark.svg"
+	},
 
 	"icons": {
 		"48": "ext/markdown-mark.svg",


### PR DESCRIPTION
Try and fix #8 using optional permissions instead of content scripts. It is incompatible with #23.

This is closer to the original idea and allows to only inject javascript when we know we need it, using a whitelist of domains. This PR adds a toolbar button, which when clicked allows rendering pages from the host opened in the current tab.

To allow an all-host wildcard, go to the preferences page of the extension and click the toolbar button from there (I'd have liked to put a setting in the page, but it can't request permissions).