### PR TITLE
Fix a little warning

### DIFF
--- a/ext/background.js
+++ b/ext/background.js
@@ -19,7 +19,7 @@ function origin(url, setting) {
 		origins.push('*://*/*');
 		if (setting) origins.push('file:///*');
 	} else if (url.protocol == 'about:') {
-		return;
+		return [];
 	} else if (url.protocol == 'file:') {
 		origins.push('file:///*');
 	} else if (setting) {


### PR DESCRIPTION
Always return a list from origin()

This returned value is then passed to browser.permissions.request({origins: ...})
and the API specifieds this always needs to be a list.