### PR TITLE
Extend the Table of Contents to a full "Markdown Viewer menu"

### DIFF
--- a/ext/content.js
+++ b/ext/content.js
@@ -137,6 +137,10 @@ function processMarkdown(textContent) {
 function addMarkdownViewerMenu() {
 	var toolsdiv = document.createElement('div');
 	toolsdiv.id = '__markdown-viewer__tools';
+	toolsdiv.className = 'hidden';
+	var getMenuDisplayDone = webext.storage.sync.get('display_menu').then(storage => {
+		toolsdiv.className = 'display_menu' in storage ? storage.display_menu : 'floating';
+	});
 
 	var input = toolsdiv.appendChild(document.createElement('input'));
 	var label = toolsdiv.appendChild(document.createElement('label'));

--- a/ext/content.js
+++ b/ext/content.js
@@ -146,8 +146,8 @@ function addMarkdownViewerMenu() {
 			var header_level = header.tagName[1] - 1;
 			for (; level < header_level; level++) {
 				if (list.lastChild == null || list.lastChild.tagName != 'LI')
-					list = list.appendChild(document.createElement('li'))
-				list = list.appendChild(document.createElement('ul'));
+					list.appendChild(document.createElement('li'))
+				list = list.lastChild.appendChild(document.createElement('ul'));
 			}
 			for (; level > header_level; level--) {
 				list = list.parentNode.parentNode;

--- a/ext/content.js
+++ b/ext/content.js
@@ -71,6 +71,7 @@ function processMarkdown(textContent) {
 	addExtensionStylesheet('/lib/sss/sss.css');
 	addExtensionStylesheet('/lib/sss/sss.print.css', 'print');
 	addExtensionStylesheet('/lib/highlightjs/styles/default.css');
+	addExtensionStylesheet('/ext/menu.css');
 	// User-defined stylesheet.
 	var styleSheetDone = addCustomStylesheet();
 

--- a/ext/content.js
+++ b/ext/content.js
@@ -140,10 +140,15 @@ function addMarkdownViewerMenu() {
 	// build a table of contents if there are any headers
 	var allHeaders = Array.from(document.querySelectorAll(headerTags.join(',')));
 	if (allHeaders.length) {
+		// list uniquely the used header titles, so we only consider those for nesting
+		var usedHeaderTags = allHeaders.map(header => header.tagName).filter((level, index, self) =>
+			self.indexOf(level) == index
+		).sort();
+
 		var level = 0, tocdiv = document.createElement('div'), list = tocdiv.appendChild(document.createElement('ul'));
 		Array.from(allHeaders).forEach(header => {
 			/* Open/close the right amount of nested lists to fit tag level */
-			var header_level = header.tagName[1] - 1;
+			var header_level = usedHeaderTags.indexOf(header.tagName);
 			for (; level < header_level; level++) {
 				if (list.lastChild == null || list.lastChild.tagName != 'LI')
 					list.appendChild(document.createElement('li'))

--- a/ext/content.js
+++ b/ext/content.js
@@ -138,6 +138,12 @@ function addMarkdownViewerMenu() {
 	var toolsdiv = document.createElement('div');
 	toolsdiv.id = '__markdown-viewer__tools';
 
+	var input = toolsdiv.appendChild(document.createElement('input'));
+	var label = toolsdiv.appendChild(document.createElement('label'));
+	input.type = 'checkbox';
+	input.id = '__markdown-viewer__show-tools';
+	label.setAttribute('for', input.id);
+
 	// build a table of contents if there are any headers
 	var allHeaders = Array.from(document.querySelectorAll(headerTags.join(',')));
 	if (allHeaders.length) {
@@ -167,6 +173,7 @@ function addMarkdownViewerMenu() {
 		});
 
 		tocdiv.id = '__markdown-viewer__toc';
+		tocdiv.className = 'toggleable'
 		toolsdiv.appendChild(tocdiv);
 	}
 

--- a/ext/content.js
+++ b/ext/content.js
@@ -54,8 +54,12 @@ async function createHTMLSourceBlob() {
 			}
 
 			/* async + await so stylesheets get processed in order, and to know when we finished parsing them all */
-			var res = await window.fetch(t.href);
-			var css = await res.text();
+			try {
+				var res = await window.fetch(t.href);
+				var css = await res.text();
+			} catch {
+				continue;
+			}
 			var style = document.createElement('style');
 			if (t.hasAttribute('media')) {
 				style.setAttribute('media', t.getAttribute('media'));

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -124,3 +124,19 @@ input#__markdown-viewer__show-tools:not(:checked) ~ .toggleable {
 #__markdown-viewer__toc ul ul {
   padding-left: 1.5em;
 }
+
+
+/* Style the "Download Source" button at the end of the menu */
+#__markdown-viewer__tools > p:last-child {
+  text-align:center;
+}
+
+#__markdown-viewer__download {
+  /* appearance: button; */
+  -moz-appearance: button !important;
+  display:inline-block;
+  text-align: center;
+  text-decoration:none;
+  color:#eee;
+  margin: .5em auto;
+}

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -110,6 +110,12 @@ input#__markdown-viewer__show-tools:not(:checked) ~ .toggleable {
   margin: 1em auto;
 }
 
+#__markdown-viewer__tools select {
+  max-width: 40%;
+  margin: 0 .5em;
+}
+
+#__markdown-viewer__tools select,
 #__markdown-viewer__toc * {
   white-space: nowrap;
   overflow: hidden;
@@ -133,8 +139,9 @@ input#__markdown-viewer__show-tools:not(:checked) ~ .toggleable {
 
 
 /* Style the "Download Source" button at the end of the menu */
-#__markdown-viewer__tools > p:last-child {
+#__markdown-viewer__tools > p {
   text-align:center;
+  padding: 0 .5em;
 }
 
 #__markdown-viewer__download {

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -23,6 +23,12 @@
   display:none;
 }
 
+@media print {
+  #__markdown-viewer__tools {
+    display: none;
+  }
+}
+
 #__markdown-viewer__tools a[href]:after {
   content: "";
 }

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -1,0 +1,52 @@
+/* Style for the menu */
+#__markdown-viewer__tools {
+  margin:0;
+  padding:0;
+  background:#555;
+  color:#eee;
+  box-shadow:0 -1px rgba(0,0,0,.5) inset;
+  border-radius: .5em;
+  float:right;
+  margin: 0 0 .5em .5em;
+}
+
+#__markdown-viewer__tools a[href]:after {
+  content: "";
+}
+
+/* style the table of contents and its items */
+#__markdown-viewer__toc {
+  display:block;
+  padding: .5em;
+  border:0;
+}
+
+#__markdown-viewer__toc::before {
+  content: "Table of Contents";
+  text-align: center;
+  display: block;
+  font-weight: bold;
+  text-decoration: underline;
+  margin: 1em auto;
+}
+
+#__markdown-viewer__toc * {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#__markdown-viewer__toc a {
+  color: white;
+  text-decoration: none;
+}
+
+#__markdown-viewer__toc ul {
+  list-style: inside "• ";
+  padding: 0;
+  margin: 0;
+}
+
+#__markdown-viewer__toc ul ul {
+  padding-left: 1.5em;
+}

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -6,6 +6,8 @@
   color:#eee;
   box-shadow:0 -1px rgba(0,0,0,.5) inset;
   border-radius: .5em;
+  max-width: 25%;
+  z-index: 2147483647;
 }
 
 #__markdown-viewer__tools.floating {
@@ -41,10 +43,19 @@ label[for=__markdown-viewer__show-tools] {
   background:#333;
   cursor:pointer;
   border-radius: .5em;
+  min-height: 3em;
+  width: .9em;
+  float: right;
+}
+
+input#__markdown-viewer__show-tools:not(:checked) ~ label {
+  margin-left: -.9em;
+}
+
+input#__markdown-viewer__show-tools:checked ~ label {
 }
 
 label[for=__markdown-viewer__show-tools]:before{
-  content:"Markdown-viewer menu";
 }
 
 label[for=__markdown-viewer__show-tools]:after {
@@ -74,19 +85,20 @@ input#__markdown-viewer__show-tools {
 
 /* style, and hide/show menu items based on the input being checked */
 #__markdown-viewer__tools > .toggleable {
-  min-width:20%;
   overflow:hidden;
-  transition-property:max-height, padding-top, padding-bottom, margin-top, margin-bottom;
+  transition-property:max-height, max-width, padding-top, padding-bottom, margin-top, margin-bottom;
   transition-duration:0.5s;
 }
 
 input#__markdown-viewer__show-tools:checked ~ .toggleable {
+  max-width: 2000px;
   max-height:300px;
   transition-timing-function:ease-in;
 }
 
 input#__markdown-viewer__show-tools:not(:checked) ~ .toggleable {
   max-height:0;
+  max-width:0;
   transition-timing-function:ease-out;
   padding-top:0;
   padding-bottom:0;

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -1,4 +1,4 @@
-/* Style for the menu */
+/* Style for the menu, possible positions/visibility */
 #__markdown-viewer__tools {
   margin:0;
   padding:0;
@@ -6,8 +6,21 @@
   color:#eee;
   box-shadow:0 -1px rgba(0,0,0,.5) inset;
   border-radius: .5em;
+}
+
+#__markdown-viewer__tools.floating {
   float:right;
   margin: 0 0 .5em .5em;
+}
+
+#__markdown-viewer__tools.fixed {
+  position:fixed;
+  top:.5em;
+  right:1em;
+}
+
+#__markdown-viewer__tools.hidden {
+  display:none;
 }
 
 #__markdown-viewer__tools a[href]:after {

--- a/ext/menu.css
+++ b/ext/menu.css
@@ -14,6 +14,67 @@
   content: "";
 }
 
+/* Style for the menu top */
+label[for=__markdown-viewer__show-tools] {
+  display:block;
+  padding:0 18px 0 12px;
+  line-height:3em;
+  background:#333;
+  cursor:pointer;
+  border-radius: .5em;
+}
+
+label[for=__markdown-viewer__show-tools]:before{
+  content:"Markdown-viewer menu";
+}
+
+label[for=__markdown-viewer__show-tools]:after {
+  content:"";
+  display:inline-block;
+  float:right;
+  margin-top:1.5em;
+  right:5px;
+  width:0;
+  height:0;
+  border-style: solid;
+  border-color: rgba(255,255,255,.5) transparent;
+  border-width: 4px 4px 0 4px;
+  transition:border-bottom .1s, border-top .1s .1s;
+}
+
+input#__markdown-viewer__show-tools:checked ~ label:after {
+  border-top-width:0;
+  border-bottom-width:4px;
+  transition:border-top .1s, border-bottom .1s .1s;
+}
+
+/* hide the input that tracks the menu's visibility */
+input#__markdown-viewer__show-tools {
+  display:none;
+}
+
+/* style, and hide/show menu items based on the input being checked */
+#__markdown-viewer__tools > .toggleable {
+  min-width:20%;
+  overflow:hidden;
+  transition-property:max-height, padding-top, padding-bottom, margin-top, margin-bottom;
+  transition-duration:0.5s;
+}
+
+input#__markdown-viewer__show-tools:checked ~ .toggleable {
+  max-height:300px;
+  transition-timing-function:ease-in;
+}
+
+input#__markdown-viewer__show-tools:not(:checked) ~ .toggleable {
+  max-height:0;
+  transition-timing-function:ease-out;
+  padding-top:0;
+  padding-bottom:0;
+  margin-top:0;
+  margin-bottom:0;
+}
+
 /* style the table of contents and its items */
 #__markdown-viewer__toc {
   display:block;

--- a/ext/options.html
+++ b/ext/options.html
@@ -14,6 +14,18 @@
 		<li>and more.</li>
 	</ul>
 
+	<h3>Markdown-viewer menu</h3>
+	<p>Select whether/how to display a Mardown-Viewer menu on rendered pages:
+	<br />
+	<select id="menu_visibility">
+		<option value="floating">Floating (top of page)</option>
+		<option value="fixed">Fixed (top of viewport)</option>
+		<option value="hidden">Disabled</option>
+	</select>
+	</p>
+	<p>A fixed menu will stay at the same position when you scroll the page, but hide text underneath.
+	A floating menu will reflow that page's text around it, but will scroll with the page.</p>
+
 	<h3>Custom CSS</h3>
 	<p>Enter custom CSS to be applied to Markdown pages here.</p>
 	<p>Click or tab out of the text area to save changes. Refresh this page to revert changes.<span id="saved" class="hidden"> &nbsp; &nbsp; SAVED</span></p>

--- a/ext/options.js
+++ b/ext/options.js
@@ -23,3 +23,13 @@ webext.storage.sync.get('custom_css', (storage) => {
 		});
 	};
 });
+
+
+var menu_visibility = document.getElementById('menu_visibility');
+webext.storage.sync.get('display_menu', (storage) => {
+	if ('display_menu' in storage) { menu_visibility.value = storage.display_menu; }
+
+	menu_visibility.onchange = () => {
+		webext.storage.sync.set({display_menu: menu_visibility.value})
+	};
+});

--- a/lib/sss/github.css
+++ b/lib/sss/github.css
@@ -1,0 +1,410 @@
+/*
+Copyright (c) 2017 Chris Patuzzo
+https://twitter.com/chrispatuzzo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+body {
+  font-family: Helvetica, arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  background-color: white;
+  padding: 30px;
+  color: #333;
+}
+
+body > *:first-child {
+  margin-top: 0 !important;
+}
+
+body > *:last-child {
+  margin-bottom: 0 !important;
+}
+
+a {
+  color: #4183C4;
+  text-decoration: none;
+}
+
+a.absent {
+  color: #cc0000;
+}
+
+a.anchor {
+  display: block;
+  padding-left: 30px;
+  margin-left: -30px;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 20px 0 10px;
+  padding: 0;
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
+  cursor: text;
+  position: relative;
+}
+
+h2:first-child, h1:first-child, h1:first-child + h2, h3:first-child, h4:first-child, h5:first-child, h6:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+h1:hover a.anchor, h2:hover a.anchor, h3:hover a.anchor, h4:hover a.anchor, h5:hover a.anchor, h6:hover a.anchor {
+  text-decoration: none;
+}
+
+h1 tt, h1 code {
+  font-size: inherit;
+}
+
+h2 tt, h2 code {
+  font-size: inherit;
+}
+
+h3 tt, h3 code {
+  font-size: inherit;
+}
+
+h4 tt, h4 code {
+  font-size: inherit;
+}
+
+h5 tt, h5 code {
+  font-size: inherit;
+}
+
+h6 tt, h6 code {
+  font-size: inherit;
+}
+
+h1 {
+  font-size: 28px;
+  color: black;
+}
+
+h2 {
+  font-size: 24px;
+  border-bottom: 1px solid #cccccc;
+  color: black;
+}
+
+h3 {
+  font-size: 18px;
+}
+
+h4 {
+  font-size: 16px;
+}
+
+h5 {
+  font-size: 14px;
+}
+
+h6 {
+  color: #777777;
+  font-size: 14px;
+}
+
+p, blockquote, ul, ol, dl, li, table, pre {
+  margin: 15px 0;
+}
+
+hr {
+  border: 0 none;
+  color: #cccccc;
+  height: 4px;
+  padding: 0;
+}
+
+body > h2:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body > h1:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body > h1:first-child + h2 {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+body > h3:first-child, body > h4:first-child, body > h5:first-child, body > h6:first-child {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+a:first-child h1, a:first-child h2, a:first-child h3, a:first-child h4, a:first-child h5, a:first-child h6 {
+  margin-top: 0;
+  padding-top: 0;
+}
+
+h1 p, h2 p, h3 p, h4 p, h5 p, h6 p {
+  margin-top: 0;
+}
+
+li p.first {
+  display: inline-block;
+}
+
+ul, ol {
+  padding-left: 30px;
+}
+
+ul :first-child, ol :first-child {
+  margin-top: 0;
+}
+
+ul :last-child, ol :last-child {
+  margin-bottom: 0;
+}
+
+dl {
+  padding: 0;
+}
+
+dl dt {
+  font-size: 14px;
+  font-weight: bold;
+  font-style: italic;
+  padding: 0;
+  margin: 15px 0 5px;
+}
+
+dl dt:first-child {
+  padding: 0;
+}
+
+dl dt > :first-child {
+  margin-top: 0;
+}
+
+dl dt > :last-child {
+  margin-bottom: 0;
+}
+
+dl dd {
+  margin: 0 0 15px;
+  padding: 0 15px;
+}
+
+dl dd > :first-child {
+  margin-top: 0;
+}
+
+dl dd > :last-child {
+  margin-bottom: 0;
+}
+
+blockquote {
+  border-left: 4px solid #dddddd;
+  padding: 0 15px;
+  color: #777777;
+}
+
+blockquote > :first-child {
+  margin-top: 0;
+}
+
+blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+table {
+  padding: 0;
+  border-collapse:collapse;
+}
+table tr {
+  border-top: 1px solid #cccccc;
+  background-color: white;
+  margin: 0;
+  padding: 0;
+}
+
+table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
+table tr th {
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr td {
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr th :first-child, table tr td :first-child {
+  margin-top: 0;
+}
+
+table tr th :last-child, table tr td :last-child {
+  margin-bottom: 0;
+}
+
+img {
+  max-width: 100%;
+}
+
+span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+span.frame > span {
+  border: 1px solid #dddddd;
+  display: block;
+  float: left;
+  overflow: hidden;
+  margin: 13px 0 0;
+  padding: 7px;
+  width: auto;
+}
+
+span.frame span img {
+  display: block;
+  float: left;
+}
+
+span.frame span span {
+  clear: both;
+  color: #333333;
+  display: block;
+  padding: 5px 0 0;
+}
+
+span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+span.align-center > span {
+  display: block;
+  overflow: hidden;
+  margin: 13px auto 0;
+  text-align: center;
+}
+
+span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+span.align-right > span {
+  display: block;
+  overflow: hidden;
+  margin: 13px 0 0;
+  text-align: right;
+}
+
+span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+span.float-left {
+  display: block;
+  margin-right: 13px;
+  overflow: hidden;
+  float: left;
+}
+
+span.float-left span {
+  margin: 13px 0 0;
+}
+
+span.float-right {
+  display: block;
+  margin-left: 13px;
+  overflow: hidden;
+  float: right;
+}
+
+span.float-right > span {
+  display: block;
+  overflow: hidden;
+  margin: 13px auto 0;
+  text-align: right;
+}
+
+code, tt {
+  margin: 0 2px;
+  padding: 0 5px;
+  white-space: nowrap;
+  border: 1px solid #eaeaea;
+  background-color: #f8f8f8;
+  border-radius: 3px;
+}
+
+pre code {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  border: none;
+  background: transparent;
+}
+
+.highlight pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px;
+}
+
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px;
+}
+
+pre code, pre tt {
+  background-color: transparent;
+  border: none;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,8 @@
 	"web_accessible_resources": [
 		"lib/sss/sss.css",
 		"lib/sss/sss.print.css",
-		"lib/highlightjs/styles/default.css"
+		"lib/highlightjs/styles/default.css",
+		"ext/menu.css"
 	],
 
 	"options_ui": {

--- a/manifest.json
+++ b/manifest.json
@@ -56,9 +56,8 @@
 	],
 
 	"web_accessible_resources": [
-		"lib/sss/sss.css",
-		"lib/sss/sss.print.css",
-		"lib/highlightjs/styles/default.css",
+		"lib/sss/*.css",
+		"lib/highlightjs/styles/*.css",
 		"ext/menu.css"
 	],
 


### PR DESCRIPTION
So this PR provides some default styling for the table of contents which looks a little better than the barebone version:
- the menu drops down
- the menu has a button to export the page as HTML
- the menu has 2 dropdowns to choose the markdown/code styles
- there is an option to fully remove the menu
- there is an option to make the menu fixed instead of floating
- the menu is still custom styleable, e.g. try the following in the custom CSS box to change colors:

      #__markdown-viewer__tools,
      #__markdown-viewer__tools > *,
      #__markdown-viewer__tools ul a {
        box-shadow:none;
        background: cornsilk;
        color: teal;
      }
      #__markdown-viewer__tools label {
        background: wheat;
      }
      #__markdown-viewer__tools label:after {
        border-color:mediumblue transparent;
      }


